### PR TITLE
Update set-up

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 .venv
+.pytest_cache
+__pycache__
+.ruff_cache
+.mypy_cache

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,5 +9,8 @@
     "editor.rulers": [
         88,
     ],
-    "python.analysis.typeCheckingMode": "strict",
+    "python.analysis.typeCheckingMode": "basic",
+    "python.analysis.extraPaths": [
+        "./esd"
+    ],
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,11 +13,21 @@ line-length = 88
 target-version = ['py311']
 
 [tool.ruff]
-# Enable pycodestyle (`E`), Pyflakes (`F`), pycodestyle warnings (`W`),
-# McCabe complexity (`C901`), pep8-naming (`N`), pydocstyle (`D`),
-# pyupgrade (`UP`) and pylint (`PL`).
-select = ["E", "F", "W", "C901", "N", "D", "UP", "PL"]
-ignore = []
+# Assume Python 3.11.
+target-version = "py311"
+
+select = [
+    "E",     # pycodestyle
+    "F",     # Pyflakes
+    "W",     # pycodestyle warnings
+    "C901",  # McCabe complexity
+    "N",     # pep8-naming
+    "D",     # pydocstyle
+    "UP",    # pyupgrade
+    "PL"     # pylint
+]
+
+ignore = ["D100"]
 
 # Allow autofix for all enabled rules (when `--fix`) is provided.
 fixable = ["ALL"]
@@ -47,6 +57,7 @@ exclude = [
     "node_modules",
     "venv",
 ]
+
 per-file-ignores = {}
 
 # Same as Black.
@@ -55,25 +66,40 @@ line-length = 88
 # Allow unused variables when underscore-prefixed.
 dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 
-# Assume Python 3.11.
-target-version = "py311"
-
-[tool.ruff.isort]
-# Placeholder for future configuration.
+[tool.ruff.extend-per-file-ignores]
+"test_*.py" = [
+    "D101",  # Missing docstring in public class
+    "D102",  # Missing docstring in public method
+    "D103",  # Missing docstring in public function
+    "D104",  # Missing docstring in public package
+]
+"conftest.py" = [
+    "D101",  # Missing docstring in public class
+    "D102",  # Missing docstring in public method
+    "D103",  # Missing docstring in public function
+    "D104",  # Missing docstring in public package
+]
 
 [tool.ruff.mccabe]
 # Flag errors (`C901`) whenever the complexity level exceeds 10.
 max-complexity = 10
 
-[tool.ruff.pep8-naming]
-# Placeholder for future configuration.
-
 [tool.ruff.pydocstyle]
 # Use Google-style docstrings.
 convention = "google"
 
+[tool.pytest.ini_options]
+minversion = "6.0"
+addopts = "-ra -q"
+testpaths = [
+    "tests",
+]
+
+# Placeholders for future configuration if required.
+[tool.ruff.isort]
+
+[tool.ruff.pep8-naming]
+
 [tool.ruff.pylint]
-# Placeholder for future configuration.
 
 [tool.ruff.pyupgrade]
-# Placeholder for future configuration.


### PR DESCRIPTION
Update .gitignore

Update vscode type checking to basic

Reconfigure Ruff to increase readability  and to ignore pydocstyle linting rules:
-  D100 in all files
-  D101, D102, D103 and D104 in test_*.py and conftest.pt files

