### PR TITLE
refactor: Separate general and specific use cases

### DIFF
--- a/esd/service_layer/cli_service.py
+++ b/esd/service_layer/cli_service.py
@@ -1,0 +1,50 @@
+from datetime import datetime
+
+from rich.console import Console
+from rich.table import Table
+
+from esd.domain.athlete import FitnessProfile
+from esd.domain.session import Workout
+from esd.service_layer.service import WorkoutService
+
+
+class CLIService:
+    """Service class for CLI related operations."""
+
+    def __init__(self, workout_service: WorkoutService):
+        """Initialise CLIService with WorkoutService."""
+        self.workout_service = workout_service
+
+    def create_and_display_table(
+        self, workout: Workout, fitness_profiles: list[FitnessProfile]
+    ) -> Table:
+        """Print a table of names, work interval and rest interval distances.
+
+        Args:
+            workout: The training variables for the workout.
+            fitness_profiles: The fitness profile for each athlete completing the
+                workout.
+        """
+        work_distances = self.workout_service.calculate_work_interval_distances(
+            workout, fitness_profiles
+        )
+        rest_distances = self.workout_service.calculate_rest_interval_distances(
+            workout, fitness_profiles
+        )
+
+        console = Console()
+        date = datetime.now().strftime("%d/%m/%Y")
+        table = Table(title=f"{workout.name} - {date}")
+        table.add_column("Athlete Name", justify="left")
+        table.add_column("Work Distance (m)", justify="center")
+        table.add_column("Rest Distance (m)", justify="center")
+
+        for athlete in work_distances:
+            table.add_row(
+                athlete,
+                f"{work_distances[athlete]}m",
+                f"{rest_distances[athlete]}m",
+            )
+
+        console.print(table)
+        return table

--- a/esd/service_layer/service.py
+++ b/esd/service_layer/service.py
@@ -1,8 +1,3 @@
-from datetime import datetime
-
-from rich.console import Console
-from rich.table import Table
-
 from esd.adapters.repository import AbstractRepository
 from esd.domain.athlete import FitnessProfile
 from esd.domain.session import Workout
@@ -31,21 +26,28 @@ class WorkoutService:
         """
         return work_interval_time * 60
 
-    def get_workout(self, id: str) -> Workout:
-        """Get a workout from the repository.
+    def get_selected_workout(self, selected_workout: str) -> Workout:
+        """Get the selected workout from the repository.
+
+        Args:
+            selected_workout: The name of the selected workout.
 
         Returns:
             A workout.
         """
-        return self.workout_repository.get(id)
+        return self.workout_repository.get(selected_workout)
 
-    def get_workouts(self) -> list[Workout]:
-        """Get all workouts from the repository.
+    def get_workout_names(self) -> list[str]:
+        """Get all workout names from the repository.
+
+        Workout names are displayed to the user to select the required workout.
 
         Returns:
-            A list of workouts.
+            A list of workout names.
         """
-        return self.workout_repository.get_all()
+        workouts = self.workout_repository.get_all()
+
+        return [workout.name for workout in workouts]
 
     def get_fitness_profiles(self) -> list[FitnessProfile]:
         """Get all fitness profiles from the repository.
@@ -55,7 +57,7 @@ class WorkoutService:
         """
         return self.fitness_profile_repository.get_all()
 
-    def _calculate_work_interval_distances(
+    def calculate_work_interval_distances(
         self, workout: Workout, fitness_profiles: list[FitnessProfile]
     ) -> dict[str, float]:
         """Calculate work interval distances for each athlete.
@@ -81,7 +83,7 @@ class WorkoutService:
             work_distances[profile.name] = work_interval_distance
         return work_distances
 
-    def _calculate_rest_interval_distances(
+    def calculate_rest_interval_distances(
         self, workout: Workout, fitness_profiles: list[FitnessProfile]
     ) -> dict[str, float]:
         """Calculate rest interval distances for each athlete.
@@ -106,37 +108,3 @@ class WorkoutService:
             )
             rest_distances[profile.name] = rest_interval_distance
         return rest_distances
-
-    def print_workout_table(
-        self, workout: Workout, fitness_profiles: list[FitnessProfile]
-    ) -> Table:
-        """Print a table of names, work interval and rest interval distances.
-
-        Args:
-            workout: The training variables for the workout.
-            fitness_profiles: The fitness profile for each athlete completing the
-                workout.
-        """
-        work_distances = self._calculate_work_interval_distances(
-            workout, fitness_profiles
-        )
-        rest_distances = self._calculate_rest_interval_distances(
-            workout, fitness_profiles
-        )
-
-        console = Console()
-        date = datetime.now().strftime("%d/%m/%Y")
-        table = Table(title=f"{workout.name} - {date}")
-        table.add_column("Athlete Name", justify="left")
-        table.add_column("Work Distance (m)", justify="center")
-        table.add_column("Rest Distance (m)", justify="center")
-
-        for athlete in work_distances:
-            table.add_row(
-                athlete,
-                f"{work_distances[athlete]}m",
-                f"{rest_distances[athlete]}m",
-            )
-
-        console.print(table)
-        return table

--- a/tests/service_layer/conftest.py
+++ b/tests/service_layer/conftest.py
@@ -6,6 +6,7 @@ from esd.adapters.fake_repository import (
 )
 from esd.domain.athlete import FitnessProfile
 from esd.domain.session import Workout
+from esd.service_layer.cli_service import CLIService
 from esd.service_layer.service import WorkoutService
 
 
@@ -121,3 +122,9 @@ def fake_fitness_profile_repository(profile_one, profile_two, profile_three):
 def workout_service(fake_workout_repository, fake_fitness_profile_repository):
     """Return a WorkoutService."""
     return WorkoutService(fake_workout_repository, fake_fitness_profile_repository)
+
+
+@pytest.fixture
+def cli_service(workout_service):
+    """Return a CLIService."""
+    return CLIService(workout_service)

--- a/tests/service_layer/test_cli_service.py
+++ b/tests/service_layer/test_cli_service.py
@@ -1,0 +1,26 @@
+from datetime import datetime
+
+
+class TestCLIService:
+    def test_print_workout_table(
+        self,
+        cli_service,
+        profiles,
+    ):
+        """Test print_workout_table method."""
+        date = datetime.now().strftime("%d/%m/%Y")
+        workout = cli_service.workout_service.get_selected_workout(
+            "Passive Long Intervals - Normal: 3 mins work / 3 mins rest"
+        )
+        profiles = cli_service.workout_service.get_fitness_profiles()
+
+        table = cli_service.create_and_display_table(workout, profiles)
+
+        assert table.title == f"{workout.name} - {date}"
+        assert table.columns[0].header == "Athlete Name"
+        assert table.columns[1].header == "Work Distance (m)"
+        assert table.columns[2].header == "Rest Distance (m)"
+
+        assert list(table.columns[0].cells) == ["John Smith", "Jane Doe", "Joe Bloggs"]
+        assert list(table.columns[1].cells) == ["751.0m", "767.0m", "720.0m"]
+        assert list(table.columns[2].cells) == ["0.0m", "0.0m", "0.0m"]

--- a/tests/service_layer/test_service.py
+++ b/tests/service_layer/test_service.py
@@ -1,5 +1,3 @@
-from datetime import datetime
-
 import pytest
 
 
@@ -21,13 +19,23 @@ class TestWorkoutService:
             ),
         ],
     )
-    def test_get_workout(
+    def test_get_selected_workout(
         self, workout_service, workout_name, expected_workout, request
     ):
-        """Test get_workout method."""
-        name = workout_service.get_workout(workout_name)
+        """Test get_selected_workout method."""
+        name = workout_service.get_selected_workout(workout_name)
         expected = request.getfixturevalue(expected_workout)
         assert name == expected
+
+    def test_get_workout_names(self, workout_service):
+        """Test get_workout_names method."""
+        workout_names = workout_service.get_workout_names()
+        expected_workout_names = [
+            "Passive Long Intervals - Normal: 3 mins work / 3 mins rest",
+            "Passive Long Intervals - Extensive: 2 mins work / 1 mins rest",
+            "Passive Long Intervals - Intensive: 2 mins work / 1 mins rest",
+        ]
+        assert workout_names == expected_workout_names
 
     def test_get_fitness_profiles(self, workout_service, profiles):
         """Test get_fitness_profile method."""
@@ -61,26 +69,3 @@ class TestWorkoutService:
             "Joe Bloggs": 0.0,
         }
         assert rest_distances == expected_rest_distances
-
-    def test_print_workout_table(
-        self,
-        workout_service,
-        profiles,
-    ):
-        """Test print_workout_table method."""
-        date = datetime.now().strftime("%d/%m/%Y")
-        workout = workout_service.get_workout(
-            "Passive Long Intervals - Normal: 3 mins work / 3 mins rest"
-        )
-        profiles = workout_service.get_fitness_profiles()
-
-        table = workout_service.print_workout_table(workout, profiles)
-
-        assert table.title == f"{workout.name} - {date}"
-        assert table.columns[0].header == "Athlete Name"
-        assert table.columns[1].header == "Work Distance (m)"
-        assert table.columns[2].header == "Rest Distance (m)"
-
-        assert list(table.columns[0].cells) == ["John Smith", "Jane Doe", "Joe Bloggs"]
-        assert list(table.columns[1].cells) == ["751.0m", "767.0m", "720.0m"]
-        assert list(table.columns[2].cells) == ["0.0m", "0.0m", "0.0m"]


### PR DESCRIPTION
Prior to this change, WorkoutService contained general and specific use cases. For example, WorkoutService included a method to create and print a table to the terminal. This method was only relavent to the CLI presentation layer.

WorkoutService now contains general use cases that are applicable to all service classes. A specific use case has been created for a CLI presentation layer (CLIService). CLIService has the attribute "workout_service" composed of a WorkoutService instance to provide it with access to the general use cases.

closes #33 