### PR TITLE
fix: Fox broken tests in test_service.py

### DIFF
--- a/tests/service_layer/test_service.py
+++ b/tests/service_layer/test_service.py
@@ -46,7 +46,7 @@ class TestWorkoutService:
         self, workout_service, profiles, workout_one
     ):
         """Test calculate_work_interval_distances method."""
-        work_distances = workout_service._calculate_work_interval_distances(
+        work_distances = workout_service.calculate_work_interval_distances(
             workout_one, profiles
         )
         expected_work_distances = {
@@ -60,7 +60,7 @@ class TestWorkoutService:
         self, workout_service, profiles, workout_one
     ):
         """Test calculate_rest_interval_distances method."""
-        rest_distances = workout_service._calculate_rest_interval_distances(
+        rest_distances = workout_service.calculate_rest_interval_distances(
             workout_one, profiles
         )
         expected_rest_distances = {


### PR DESCRIPTION
Prior to this change, 'test_calculate_work_interval_distances' and 'test_calculate_rest_interval_distances'in test_service.py  were failing due incorrect  method names called in the tests.

A previous commit had removed the underscore from
'_calculate_work_interval_distances' and
'_calculate_rest_interval_distances' in the WorkoutService class. The tests were still using the method names with a underscore prefix.

This change corrects the method names called in the 'test_calculate_work_interval_distances' and
'test_calculate_rest_interval_distances' tests to match the WorkoutService method names.