### PR TITLE
fix: Correct data format in conditioning_workouts.csv

### DIFF
--- a/data/conditioning_workouts.csv
+++ b/data/conditioning_workouts.csv
@@ -1,4 +1,4 @@
 workout_name,work_interval_time,work_interval_percentage_mas,work_interval_percentage_asr,rest_interval_time,rest_interval_percentage_mas,rest_interval_percentage_asr
-Passive Long Intervals - Normal,2,100,0,2,0,0
-Passive Long Intervals - Extensive,2,100,0,1,0,0
-Passive Long Intervals - Intensive,2,100,0,3,0,0
+Passive Long Intervals - Normal,2,1.0,0,2,0,0
+Passive Long Intervals - Extensive,2,1.0,0,1,0,0
+Passive Long Intervals - Intensive,2,1.0,0,3,0,0


### PR DESCRIPTION
Prior to this change, the data format for work_interval_percentage_mas was in percentage format.
WorkoutService methods 'calculate_work_interval_distance' and
'calculate_rest_interval_distances' required the data as a decimal.

This change updates the csv file to contain the
work_interval_percentage_mas as a decimal.