### PR TITLE
feat: Add __main__.py module

### DIFF
--- a/esd/__main__.py
+++ b/esd/__main__.py
@@ -1,0 +1,3 @@
+from esd.entry_points.cli import cli
+
+cli()

--- a/esd/entry_points/cli.py
+++ b/esd/entry_points/cli.py
@@ -8,7 +8,7 @@ from esd.service_layer.cli_service import CLIService
 from esd.service_layer.service import WorkoutService
 
 
-def main():
+def cli():
     """Entry point for the command-line interface (CLI).
 
     It prompts the user to select a workout from a list of available workouts, and then
@@ -37,4 +37,4 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    cli()


### PR DESCRIPTION
Prior to this change, the cli is run with the following command:

`>>> python -m esd.entry_points.cli`

The change will simplify the command to run the cli interface to:

`>>> python -m esd`

This change add a __main__.py module which imports and calls the cli function to run the cli interface.