### PR TITLE
feat[domain]: Create entity to store assessment results

### DIFF
--- a/esd/domain/assessment.py
+++ b/esd/domain/assessment.py
@@ -1,0 +1,34 @@
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Self
+
+
+@dataclass
+class Assessment:
+    """Represents an assessment result.
+
+    Attributes:
+        athlete_name: A str of the athlete's name.
+        date: A str of the date of the assessment.
+        type: A str of the type of assessment.
+        distance: An int of the assessment distance in meters.
+        time: A float of the time taken to complete the assessment.
+    """
+
+    athlete_name: str
+    date: str
+    type: str
+    distance: int
+    time: float
+
+    @classmethod
+    def from_dict(cls, d: Mapping) -> Self:
+        """Create Assessment instance from dictionary.
+
+        Args:
+            d: A mapping of Assessment dataclass fields to values
+
+        Returns:
+            Self: An instance of the Assessment class
+        """
+        return cls(**d)

--- a/tests/domain/conftest.py
+++ b/tests/domain/conftest.py
@@ -1,8 +1,20 @@
 import pytest
 
+from esd.domain.assessment import Assessment
 from esd.domain.athlete import Athlete
 from esd.domain.profile import FitnessProfile
 from esd.domain.session import Workout
+
+
+@pytest.fixture
+def assessment_2km_time_trial():
+    return Assessment(
+        athlete_name="John Smith",
+        date="01/01/2021",
+        type="2km time trial",
+        distance=2000,
+        time=480,
+    )
 
 
 @pytest.fixture

--- a/tests/domain/test_assessment.py
+++ b/tests/domain/test_assessment.py
@@ -1,0 +1,26 @@
+from esd.domain.assessment import Assessment
+
+
+class TestAssessment:
+    def test_assessment_init(self, assessment_2km_time_trial: Assessment):
+        """Test Assessment instance is created as expected."""
+        assessment = assessment_2km_time_trial
+
+        assert assessment.athlete_name == "John Smith"
+        assert assessment.date == "01/01/2021"
+        assert assessment.type == "2km time trial"
+        assert assessment.distance == 2000  # noqa: PLR2004
+        assert assessment.time == 480  # noqa: PLR2004
+
+    def test_assessment_from_dict(self, assessment_2km_time_trial: Assessment):
+        """Test Assessment instance is created from dictionary as expected."""
+        init_dict = {
+            "athlete_name": "John Smith",
+            "date": "01/01/2021",
+            "type": "2km time trial",
+            "distance": 2000,
+            "time": 480,
+        }
+        assessment = Assessment.from_dict(init_dict)
+
+        assert assessment == assessment_2km_time_trial


### PR DESCRIPTION
Prior to this change, the newest 2km time trial and 5m sprint assessment results were loaded and stored as attributes of the `FitnessProfile` class. With future feature development requiring the ability to create, read, update and delete individual assessment results, an assessment entity was required in the domain logic.

This change adds the `Assessment` dataclass and associated tests.