### PR TITLE
feat[domain]: Store assessments in Athlete class

### DIFF
--- a/esd/domain/assessment.py
+++ b/esd/domain/assessment.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 from typing import Self
 
 
-@dataclass
+@dataclass(frozen=True)
 class Assessment:
     """Represents an assessment result.
 

--- a/esd/domain/athlete.py
+++ b/esd/domain/athlete.py
@@ -1,9 +1,6 @@
-from collections.abc import Mapping
-from dataclasses import dataclass, field
-from typing import Self
+from esd.domain.assessment import Assessment
 
 
-@dataclass
 class Athlete:
     """Represents an athlete and their identifying information.
 
@@ -13,25 +10,41 @@ class Athlete:
         name: A str of the athlete's full name.
         date_of_birth: A str of the athlete's date of birth.
         sport: A str of the athlete's sport.
+        assessments: A set of Assessment instances.
     """
 
-    forename: str
-    surname: str
-    name: str = field(init=False)
-    date_of_birth: str
-    sport: str
-
-    def __post_init__(self) -> None:  # noqa: D105
-        self.name = f"{self.forename} {self.surname}"
-
-    @classmethod
-    def from_dict(cls, mapping: Mapping) -> Self:
-        """Create Athlete instance from dictionary.
+    def __init__(self, forename: str, surname: str, date_of_birth: str, sport: str):
+        """Initialize Athlete instance.
 
         Args:
-            mapping: A mapping of Athlete dataclass fields to values
+            forename: A str of the athlete's forename.
+            surname: A str of the athlete's surname.
+            date_of_birth: A str of the athlete's date of birth.
+            sport: A str of the athlete's sport.
+        """
+        self.forename = forename
+        self.surname = surname
+        self.name = f"{forename} {surname}"
+        self.date_of_birth = date_of_birth
+        self.sport = sport
+        self.assessments: set = set()
+
+    def can_assign_assessment(self, assessment: Assessment) -> bool:
+        """Check if athlete can be assigned an assessment.
+
+        Args:
+            assessment: An Assessment instance
 
         Returns:
-            Self: An instance of the Athlete class
+            bool: True if athlete can be assigned assessment, else False
         """
-        return cls(**mapping)
+        return assessment.athlete_name == self.name
+
+    def assign_assessment(self, assessment: Assessment) -> None:
+        """Assign an assessment to athlete.
+
+        Args:
+            assessment: An Assessment instance
+        """
+        if self.can_assign_assessment(assessment):
+            self.assessments.add(assessment)

--- a/tests/domain/conftest.py
+++ b/tests/domain/conftest.py
@@ -7,7 +7,17 @@ from esd.domain.session import Workout
 
 
 @pytest.fixture
-def assessment_2km_time_trial():
+def athlete_john_smith():
+    return Athlete(
+        forename="John",
+        surname="Smith",
+        date_of_birth="01/01/2000",
+        sport="Boxing",
+    )
+
+
+@pytest.fixture
+def john_smith_2km_time_trial():
     return Assessment(
         athlete_name="John Smith",
         date="01/01/2021",
@@ -18,9 +28,13 @@ def assessment_2km_time_trial():
 
 
 @pytest.fixture
-def athlete_john_smith():
-    return Athlete(
-        forename="John", surname="Smith", date_of_birth="01/01/2000", sport="Boxing"
+def anne_other_2km_time_trial():
+    return Assessment(
+        athlete_name="Anne Other",
+        date="01/01/2021",
+        type="2km time trial",
+        distance=2000,
+        time=480,
     )
 
 

--- a/tests/domain/test_assessment.py
+++ b/tests/domain/test_assessment.py
@@ -2,9 +2,9 @@ from esd.domain.assessment import Assessment
 
 
 class TestAssessment:
-    def test_assessment_init(self, assessment_2km_time_trial: Assessment):
+    def test_assessment_init(self, john_smith_2km_time_trial: Assessment):
         """Test Assessment instance is created as expected."""
-        assessment = assessment_2km_time_trial
+        assessment = john_smith_2km_time_trial
 
         assert assessment.athlete_name == "John Smith"
         assert assessment.date == "01/01/2021"
@@ -12,7 +12,7 @@ class TestAssessment:
         assert assessment.distance == 2000  # noqa: PLR2004
         assert assessment.time == 480  # noqa: PLR2004
 
-    def test_assessment_from_dict(self, assessment_2km_time_trial: Assessment):
+    def test_assessment_from_dict(self, john_smith_2km_time_trial: Assessment):
         """Test Assessment instance is created from dictionary as expected."""
         init_dict = {
             "athlete_name": "John Smith",
@@ -23,4 +23,4 @@ class TestAssessment:
         }
         assessment = Assessment.from_dict(init_dict)
 
-        assert assessment == assessment_2km_time_trial
+        assert assessment == john_smith_2km_time_trial

--- a/tests/domain/test_athlete.py
+++ b/tests/domain/test_athlete.py
@@ -1,8 +1,5 @@
-from esd.domain.athlete import Athlete
-
-
 class TestAthlete:
-    def test_athlete_init(self, athlete_john_smith: Athlete):
+    def test_athlete_init(self, athlete_john_smith):
         athlete = athlete_john_smith
 
         assert athlete.forename == "John"
@@ -10,15 +7,36 @@ class TestAthlete:
         assert athlete.name == "John Smith"
         assert athlete.date_of_birth == "01/01/2000"
         assert athlete.sport == "Boxing"
+        assert athlete.assessments == set()
 
-    def test_athlete_from_dict(self, athlete_john_smith: Athlete):
-        init_dict = {
-            "forename": "John",
-            "surname": "Smith",
-            "date_of_birth": "01/01/2000",
-            "sport": "Boxing",
-        }
+    def test_can_assign_assessment(self, athlete_john_smith, john_smith_2km_time_trial):
+        athlete = athlete_john_smith
+        assessment = john_smith_2km_time_trial
 
-        athlete = Athlete(**init_dict)
+        assert athlete.can_assign_assessment(assessment)
 
-        assert athlete == athlete_john_smith
+    def test_cannot_assign_assessment(
+        self, athlete_john_smith, anne_other_2km_time_trial
+    ):
+        athlete = athlete_john_smith
+        assessment = anne_other_2km_time_trial
+
+        assert not athlete.can_assign_assessment(assessment)
+
+    def test_assign_assessment(self, athlete_john_smith, john_smith_2km_time_trial):
+        athlete = athlete_john_smith
+        assessment = john_smith_2km_time_trial
+
+        athlete.assign_assessment(assessment)
+
+        assert assessment in athlete.assessments
+
+    def cannot_assign_assessment_if_names_do_not_match(
+        self, athlete_john_smith, anne_other_2km_time_trial
+    ):
+        athlete = athlete_john_smith
+        assessment = anne_other_2km_time_trial
+
+        athlete.assign_assessment(assessment)
+
+        assert assessment not in athlete.assessments


### PR DESCRIPTION
Prior to this change, the Athlete class couldn't store assessments.

This change adds the functionality to assign and store assessments within the athlete class.