### PR TITLE
feat: create database tables and mappers

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+DATABASE_URL= "sqlite:///:memory:"

--- a/esd/adapters/orm.py
+++ b/esd/adapters/orm.py
@@ -1,0 +1,44 @@
+import os
+
+from dotenv import load_dotenv
+from sqlalchemy import Table, Column, Float, Integer, String, create_engine
+from sqlalchemy.orm import registry, sessionmaker
+
+from esd.domain.profile import FitnessProfile
+from esd.domain.session import Workout
+
+load_dotenv()
+DATABASE_URL = os.environ["DATABASE_URL"]
+session_factory = sessionmaker(bind=create_engine(DATABASE_URL, echo=True))
+
+
+def create_tables_and_mappers():
+    """Create tables and mappers for the database."""
+    mapper_registry = registry()
+
+    fitness_profile_table = Table(
+        "fitness_profile",
+        mapper_registry.metadata,
+        Column("id", Integer, primary_key=True),
+        Column("name", String(50)),
+        Column("time_trial_distance", Integer),
+        Column("sprint_distance", Integer),
+        Column("time_trial_time", Integer),
+        Column("sprint_time", Float),
+    )
+
+    workouts_table = Table(
+        "workouts",
+        mapper_registry.metadata,
+        Column("id", Integer, primary_key=True),
+        Column("workout_type", String(50)),
+        Column("work_interval_time", Integer),
+        Column("work_interval_percentage_mas", Float),
+        Column("work_interval_percentage_asr", Float, nullable=True),
+        Column("rest_interval_time", Integer),
+        Column("rest_interval_percentage_mas", Float),
+        Column("rest_interval_percentage_asr", Float, nullable=True),
+    )
+
+    mapper_registry.map_imperatively(FitnessProfile, fitness_profile_table)
+    mapper_registry.map_imperatively(Workout, workouts_table)

--- a/requirements.in
+++ b/requirements.in
@@ -1,2 +1,3 @@
 SQLAlchemy
 rich
+python-dotenv

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,8 @@ mdurl==0.1.2
     # via markdown-it-py
 pygments==2.16.1
     # via rich
+python-dotenv==1.0.0
+    # via -r requirements.in
 rich==13.5.2
     # via -r requirements.in
 sqlalchemy==2.0.17


### PR DESCRIPTION
Prior to this change, the application was using CSV files for persistence. The application will be moving to a relational database. As a first step, database tables and mapper (between database table and Python objects) are required.

This change:
1. Adds database tables for fitness profiles and workouts and maps them against the associated Python classes FitnessProfile and Workout using SQLAlchemy.
2. Temporarily moves database initiation to orm.py (DATABASE_URL and session_factory). These will move to the api entry point once api code is added to the application.